### PR TITLE
(iotd) Multi-fetch images and use image CT from backend config

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,8 @@
 {
   "projectId": "g1xont",
-  "baseUrl": "http://localhost:4400"
+  "baseUrl": "http://localhost:4400",
+  "retries": {
+    "runMode": 2,
+    "openMode": 0
+  }
 }

--- a/cypress/fixtures/api/images/images_1_and_2.json
+++ b/cypress/fixtures/api/images/images_1_and_2.json
@@ -1,0 +1,28 @@
+{
+  "count": 1,
+  "results": [
+    {
+      "user": 1,
+      "pk": 1,
+      "hash": "abc123",
+      "title": "Test image",
+      "imageFile": "http://localhost:8084/media/images/test.png",
+      "isWip": false,
+      "skipNotifications": false,
+      "w": 1000,
+      "h": 1000
+    },
+    {
+      "user": 2,
+      "pk": 2,
+      "hash": "abc123",
+      "title": "Test image",
+      "imageFile": "http://localhost:8084/media/images/test.png",
+      "isWip": false,
+      "skipNotifications": false,
+      "w": 1000,
+      "h": 1000
+    }
+  ]
+}
+

--- a/cypress/fixtures/api/json/app-config.json
+++ b/cypress/fixtures/api/json/app-config.json
@@ -17,6 +17,7 @@
   "PREMIUM_PRICE_PREMIUM_2020": 40,
   "PREMIUM_PRICE_ULTIMATE_2020": 60,
   "REQUEST_COUNTRY": "us",
+  "IMAGE_CONTENT_TYPE_ID": 1,
   "THUMBNAIL_ALIASES": {
     "regular": {
       "size": [

--- a/cypress/integration/iotd/review-queue.js
+++ b/cypress/integration/iotd/review-queue.js
@@ -2,13 +2,6 @@ context("IOTD Review queue", () => {
   beforeEach(() => {
     cy.server();
     cy.setupInitializationRoutes();
-
-    cy.route("GET", "**/api/v2/common/contenttypes/?app_label=astrobin&model=image", {
-      id: 1,
-      appLabel: "astrobin",
-      model: "image"
-    }).as("getContentType");
-
     cy.route("GET", "**/api/v2/platesolving/solutions/*", []).as("getSolution");
   });
 
@@ -40,7 +33,7 @@ context("IOTD Review queue", () => {
     });
 
     it("should render page elements", () => {
-      cy.route("GET", "**/api/v2/images/image/*/", "fixture:api/images/image_1.json").as("getImage");
+      cy.route("GET", "**/api/v2/images/image/?ids=1,2", "fixture:api/images/images_1_and_2.json").as("getImages");
       cy.route("GET", "**/*/final/thumb/story/", "fixture:api/images/image_thumbnail_1_story_loaded.json").as(
         "getImageThumbnail"
       );

--- a/cypress/integration/iotd/submission-queue.js
+++ b/cypress/integration/iotd/submission-queue.js
@@ -2,13 +2,6 @@ context("IOTD Submission queue", () => {
   beforeEach(() => {
     cy.server();
     cy.setupInitializationRoutes();
-
-    cy.route("GET", "**/api/v2/common/contenttypes/?app_label=astrobin&model=image", {
-      id: 1,
-      appLabel: "astrobin",
-      model: "image"
-    }).as("getContentType");
-
     cy.route("GET", "**/api/v2/platesolving/solutions/*", []).as("getSolution");
   });
 
@@ -40,7 +33,7 @@ context("IOTD Submission queue", () => {
     });
 
     it("should render page elements", () => {
-      cy.route("GET", "**/api/v2/images/image/*/", "fixture:api/images/image_1.json").as("getImage");
+      cy.route("GET", "**/api/v2/images/image/?ids=*", "fixture:api/images/images_1_and_2.json").as("getImages");
       cy.route("GET", "**/*/final/thumb/story/", "fixture:api/images/image_thumbnail_1_story_loaded.json").as(
         "getImageThumbnail"
       );

--- a/src/app/features/iotd/components/base-promotion-entry/base-promotion-entry.component.ts
+++ b/src/app/features/iotd/components/base-promotion-entry/base-promotion-entry.component.ts
@@ -1,8 +1,7 @@
 import { Component, Input, OnInit } from "@angular/core";
-import { LoadContentType } from "@app/store/actions/content-type.actions";
 import { ShowFullscreenImage } from "@app/store/actions/fullscreen-image.actions";
 import { LoadSolution } from "@app/store/actions/solution.actions";
-import { selectContentType } from "@app/store/selectors/app/content-type.selectors";
+import { selectApp } from "@app/store/selectors/app/app.selectors";
 import { selectSolution } from "@app/store/selectors/app/solution.selectors";
 import { State } from "@app/store/state";
 import { PromotionImageInterface } from "@features/iotd/store/iotd.reducer";
@@ -11,7 +10,7 @@ import { BaseComponentDirective } from "@shared/components/base-component.direct
 import { ImageAlias } from "@shared/enums/image-alias.enum";
 import { SolutionInterface } from "@shared/interfaces/solution.interface";
 import { Observable } from "rxjs";
-import { filter, switchMap, tap } from "rxjs/operators";
+import { map, switchMap, take, tap } from "rxjs/operators";
 
 @Component({
   selector: "astrobin-base-promotion-entry",
@@ -29,20 +28,14 @@ export abstract class BasePromotionEntryComponent extends BaseComponentDirective
   }
 
   ngOnInit() {
-    const contentTypeOptions = {
-      appLabel: "astrobin",
-      model: "image"
-    };
-
-    this.store$.dispatch(new LoadContentType(contentTypeOptions));
-
-    this.solution$ = this.store$.select(selectContentType, contentTypeOptions).pipe(
-      filter(contentType => !!contentType),
-      tap(contentType =>
-        this.store$.dispatch(new LoadSolution({ contentType: contentType.id, objectId: "" + this.entry.pk }))
+    this.solution$ = this.store$.select(selectApp).pipe(
+      take(1),
+      map(state => state.backendConfig.IMAGE_CONTENT_TYPE_ID),
+      tap(contentTypeId =>
+        this.store$.dispatch(new LoadSolution({ contentType: contentTypeId, objectId: "" + this.entry.pk }))
       ),
-      switchMap(contentType =>
-        this.store$.select(selectSolution, { contentType: contentType.id, objectId: "" + this.entry.pk })
+      switchMap(contentTypeId =>
+        this.store$.select(selectSolution, { contentType: contentTypeId, objectId: "" + this.entry.pk })
       )
     );
   }

--- a/src/app/features/iotd/store/iotd.effects.ts
+++ b/src/app/features/iotd/store/iotd.effects.ts
@@ -182,6 +182,14 @@ export class IotdEffects {
     tap(() => this.loadingService.setLoading(true)),
     mergeMap(action =>
       this.reviewQueueApiService.getEntries(action.payload.page).pipe(
+        tap(entries => this.store$.dispatch(new LoadImages(entries.results.map(entry => entry.pk)))),
+        switchMap(entries =>
+          this.store$.select(selectImages).pipe(
+            skip(1),
+            take(1),
+            map(images => entries)
+          )
+        ),
         map(entries => new LoadReviewQueueSuccess(entries)),
         catchError(() => of(new LoadReviewQueueFailure()))
       )

--- a/src/app/features/iotd/store/iotd.effects.ts
+++ b/src/app/features/iotd/store/iotd.effects.ts
@@ -1,13 +1,17 @@
 import { Injectable } from "@angular/core";
+import { LoadImages } from "@app/store/actions/image.actions";
+import { selectImages } from "@app/store/selectors/app/image.selectors";
+import { State } from "@app/store/state";
 import { ReviewQueueApiService } from "@features/iotd/services/review-queue-api.service";
 import { SubmissionQueueApiService } from "@features/iotd/services/submission-queue-api.service";
 import { Actions, Effect, ofType } from "@ngrx/effects";
+import { Store } from "@ngrx/store";
 import { TranslateService } from "@ngx-translate/core";
 import { LoadingService } from "@shared/services/loading.service";
 import { PopNotificationsService } from "@shared/services/pop-notifications.service";
 import { WindowRefService } from "@shared/services/window-ref.service";
 import { of } from "rxjs";
-import { catchError, map, mergeMap, tap } from "rxjs/operators";
+import { catchError, map, mergeMap, skip, switchMap, take, tap } from "rxjs/operators";
 import {
   DeleteSubmissionFailure,
   DeleteSubmissionSuccess,
@@ -42,6 +46,14 @@ export class IotdEffects {
     tap(() => this.loadingService.setLoading(true)),
     mergeMap(action =>
       this.submissionQueueApiService.getEntries(action.payload.page).pipe(
+        tap(entries => this.store$.dispatch(new LoadImages(entries.results.map(entry => entry.pk)))),
+        switchMap(entries =>
+          this.store$.select(selectImages).pipe(
+            skip(1),
+            take(1),
+            map(images => entries)
+          )
+        ),
         map(entries => new LoadSubmissionQueueSuccess(entries)),
         catchError(error => of(new LoadSubmissionQueueFailure()))
       )
@@ -291,6 +303,7 @@ export class IotdEffects {
   );
 
   constructor(
+    public readonly store$: Store<State>,
     public readonly actions$: Actions<IotdActions>,
     public readonly submissionQueueApiService: SubmissionQueueApiService,
     public readonly reviewQueueApiService: ReviewQueueApiService,

--- a/src/app/shared/generators/backend-config.generator.ts
+++ b/src/app/shared/generators/backend-config.generator.ts
@@ -24,6 +24,7 @@ export class BackendConfigGenerator {
       MAX_IMAGE_PIXELS: 16536 * 16536,
       GOOGLE_ADS_ID: "GOOGLE_ADS_1234",
       REQUEST_COUNTRY: "us",
+      IMAGE_CONTENT_TYPE_ID: 1,
       THUMBNAIL_ALIASES: {
         [ImageAlias.REGULAR]: {
           size: [620, 0]

--- a/src/app/shared/generators/image.generator.ts
+++ b/src/app/shared/generators/image.generator.ts
@@ -1,20 +1,20 @@
 import { ImageInterface } from "../interfaces/image.interface";
 
 export class ImageGenerator {
-  static image(): ImageInterface {
+  static image(source: Partial<ImageInterface> = {}): ImageInterface {
     return {
-      user: 1,
-      pk: 1,
-      hash: "abc123",
-      title: "Generated image",
-      imageFile: "/media/images/generated.jpg",
-      isWip: false,
-      skipNotifications: false,
-      w: 1000,
-      h: 1000,
-      imagingTelescopes: [],
-      imagingCameras: [],
-      published: new Date().toISOString()
+      user: source.user || 1,
+      pk: source.pk || 1,
+      hash: source.hash || "abc123",
+      title: source.title || "Generated image",
+      imageFile: source.imageFile || "/media/images/generated.jpg",
+      isWip: source.isWip || false,
+      skipNotifications: source.skipNotifications || false,
+      w: source.w || 1000,
+      h: source.h || 1000,
+      imagingTelescopes: source.imagingTelescopes || [],
+      imagingCameras: source.imagingCameras || [],
+      published: source.published || new Date().toISOString()
     };
   }
 }

--- a/src/app/shared/interfaces/backend-config.interface.ts
+++ b/src/app/shared/interfaces/backend-config.interface.ts
@@ -27,6 +27,7 @@ export interface BackendConfigInterface {
   MAX_IMAGE_PIXELS: number;
   GOOGLE_ADS_ID?: string;
   REQUEST_COUNTRY: string;
+  IMAGE_CONTENT_TYPE_ID: number;
   THUMBNAIL_ALIASES: ThumbnailAliases;
   IOTD_SUBMISSION_MAX_PER_DAY: number;
   IOTD_REVIEW_MAX_PER_DAY: number;

--- a/src/app/shared/services/api/classic/images/image/image-api.service-interface.ts
+++ b/src/app/shared/services/api/classic/images/image/image-api.service-interface.ts
@@ -1,6 +1,0 @@
-import { ImageInterface } from "@shared/interfaces/image.interface";
-import { Observable } from "rxjs";
-
-export interface ImageApiServiceInterface {
-  getImage(id: number): Observable<ImageInterface>;
-}

--- a/src/app/shared/services/api/classic/images/image/image-api.service.spec.ts
+++ b/src/app/shared/services/api/classic/images/image/image-api.service.spec.ts
@@ -40,6 +40,19 @@ describe("ImageApiService", () => {
     req.flush(image);
   });
 
+  it("getImages should work", () => {
+    const images = [ImageGenerator.image({ pk: 1 }), ImageGenerator.image({ pk: 2 })];
+
+    service.getImages([images[0].pk, images[1].pk]).subscribe(response => {
+      expect(response.results[0]).toEqual(images[0]);
+      expect(response.results[1]).toEqual(images[1]);
+    });
+
+    const req = httpMock.expectOne(`${service.configUrl}/image/?ids=1,2`);
+    expect(req.request.method).toBe("GET");
+    req.flush({ results: images });
+  });
+
   it("getThumbnail should work", () => {
     const image = ImageGenerator.image();
 

--- a/src/app/shared/services/api/classic/images/image/image-api.service.ts
+++ b/src/app/shared/services/api/classic/images/image/image-api.service.ts
@@ -7,14 +7,14 @@ import { ImageAlias } from "@shared/enums/image-alias.enum";
 import { ImageThumbnailInterface } from "@shared/interfaces/image-thumbnail.interface";
 import { ImageInterface } from "@shared/interfaces/image.interface";
 import { BaseClassicApiService } from "@shared/services/api/classic/base-classic-api.service";
+import { PaginatedApiResultInterface } from "@shared/services/api/interfaces/paginated-api-result.interface";
 import { LoadingService } from "@shared/services/loading.service";
 import { Observable } from "rxjs";
-import { ImageApiServiceInterface } from "./image-api.service-interface";
 
 @Injectable({
   providedIn: "root"
 })
-export class ImageApiService extends BaseClassicApiService implements ImageApiServiceInterface {
+export class ImageApiService extends BaseClassicApiService {
   configUrl = this.baseUrl + "/images";
 
   constructor(
@@ -27,6 +27,10 @@ export class ImageApiService extends BaseClassicApiService implements ImageApiSe
 
   getImage(id: number): Observable<ImageInterface> {
     return this.http.get<ImageInterface>(`${this.configUrl}/image/${id}/`);
+  }
+
+  getImages(ids: number[]): Observable<PaginatedApiResultInterface<ImageInterface>> {
+    return this.http.get<PaginatedApiResultInterface<ImageInterface>>(`${this.configUrl}/image/?ids=${ids.join(",")}`);
   }
 
   getThumbnail(id: number | string, revision: string, alias: ImageAlias): Observable<ImageThumbnailInterface> {

--- a/src/app/store/actions/app.actions.ts
+++ b/src/app/store/actions/app.actions.ts
@@ -3,7 +3,7 @@
 import { LoadCamera, LoadCameraSuccess } from "@app/store/actions/camera.actions";
 import { LoadContentType, LoadContentTypeSuccess } from "@app/store/actions/content-type.actions";
 import { HideFullscreenImage, ShowFullscreenImage } from "@app/store/actions/fullscreen-image.actions";
-import { LoadImage, LoadImageSuccess } from "@app/store/actions/image.actions";
+import { LoadImage, LoadImages, LoadImagesSuccess, LoadImageSuccess } from "@app/store/actions/image.actions";
 import { InitializeApp, InitializeAppSuccess } from "@app/store/actions/initialize-app.actions";
 import { LoadSolution, LoadSolutionSuccess } from "@app/store/actions/solution.actions";
 import { LoadTelescope, LoadTelescopeSuccess } from "@app/store/actions/telescope.actions";
@@ -21,6 +21,9 @@ export enum AppActionTypes {
 
   LOAD_IMAGE = "[App] Load image",
   LOAD_IMAGE_SUCCESS = "[App] Load image success",
+
+  LOAD_IMAGES = "[App] Load images",
+  LOAD_IMAGES_SUCCESS = "[App] Load images success",
 
   LOAD_THUMBNAIL = "[App] Load thumbnail",
   LOAD_THUMBNAIL_SUCCESS = "[App] Load thumbnail success",
@@ -44,6 +47,8 @@ export type All =
   | LoadContentTypeSuccess
   | LoadImage
   | LoadImageSuccess
+  | LoadImages
+  | LoadImagesSuccess
   | LoadThumbnail
   | LoadThumbnailSuccess
   | LoadSolution

--- a/src/app/store/actions/image.actions.ts
+++ b/src/app/store/actions/image.actions.ts
@@ -3,6 +3,7 @@
 import { AppActionTypes } from "@app/store/actions/app.actions";
 import { Action } from "@ngrx/store";
 import { ImageInterface } from "@shared/interfaces/image.interface";
+import { PaginatedApiResultInterface } from "@shared/services/api/interfaces/paginated-api-result.interface";
 
 export class LoadImage implements Action {
   readonly type = AppActionTypes.LOAD_IMAGE;
@@ -14,4 +15,16 @@ export class LoadImageSuccess implements Action {
   readonly type = AppActionTypes.LOAD_IMAGE_SUCCESS;
 
   constructor(public payload: ImageInterface) {}
+}
+
+export class LoadImages implements Action {
+  readonly type = AppActionTypes.LOAD_IMAGES;
+
+  constructor(public payload: number[]) {}
+}
+
+export class LoadImagesSuccess implements Action {
+  readonly type = AppActionTypes.LOAD_IMAGES_SUCCESS;
+
+  constructor(public payload: PaginatedApiResultInterface<ImageInterface>) {}
 }

--- a/src/app/store/effects/image.effects.ts
+++ b/src/app/store/effects/image.effects.ts
@@ -1,6 +1,6 @@
 import { Injectable } from "@angular/core";
 import { All, AppActionTypes } from "@app/store/actions/app.actions";
-import { LoadImageSuccess } from "@app/store/actions/image.actions";
+import { LoadImagesSuccess, LoadImageSuccess } from "@app/store/actions/image.actions";
 import { selectImage } from "@app/store/selectors/app/image.selectors";
 import { State } from "@app/store/state";
 import { Actions, Effect, ofType } from "@ngrx/effects";
@@ -30,6 +30,20 @@ export class ImageEffects {
 
   @Effect({ dispatch: false })
   LoadImageSuccess: Observable<void> = this.actions$.pipe(ofType(AppActionTypes.LOAD_IMAGE_SUCCESS));
+
+  @Effect()
+  LoadImages: Observable<LoadImagesSuccess> = this.actions$.pipe(
+    ofType(AppActionTypes.LOAD_IMAGES),
+    mergeMap(action =>
+      this.imageApiService.getImages(action.payload).pipe(
+        map(response => new LoadImagesSuccess(response)),
+        catchError(error => EMPTY)
+      )
+    )
+  );
+
+  @Effect({ dispatch: false })
+  LoadImagesSuccess: Observable<void> = this.actions$.pipe(ofType(AppActionTypes.LOAD_IMAGES_SUCCESS));
 
   constructor(
     public readonly store$: Store<State>,

--- a/src/app/store/reducers/app.reducers.ts
+++ b/src/app/store/reducers/app.reducers.ts
@@ -96,6 +96,13 @@ export function reducer(state = initialAppState, action: All): AppState {
       };
     }
 
+    case AppActionTypes.LOAD_IMAGES_SUCCESS: {
+      return {
+        ...state,
+        images: new UtilsService().arrayUniqueObjects([...state.images, ...action.payload.results])
+      };
+    }
+
     case AppActionTypes.LOAD_THUMBNAIL_SUCCESS: {
       return {
         ...state,


### PR DESCRIPTION
This improve performance by removing a lot of API calls.

Closes #504