### PR TITLE
Enhance astrobin-ng setup with local Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:23
+
+# Set the working directory
+WORKDIR /code
+COPY . /code
+
+EXPOSE 4400
+
+CMD ["sh", "-c", "npm ci && npm run start"]

--- a/README.md
+++ b/README.md
@@ -8,13 +8,16 @@ AstroBin NG, based on [Node.js](https://nodejs.org), [Angular](https://angular.i
 
 [AstroBin NG](https://github.com/astrobin/astrobin-ng).
 
-## Installation
+## Running the application
+
+### Running it natively
+#### Installation
 
 ```bash
 $ npm ci
 ```
 
-## Running it
+#### Running it
 
 ```bash
 # development
@@ -22,6 +25,11 @@ $ npm run start
 
 # production mode
 $ npm run start:prod
+```
+
+### Running it with Docker
+```bash
+$ docker compose up
 ```
 
 ## Test

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AstroBin NG, based on [Node.js](https://nodejs.org), [Angular](https://angular.i
 ## Running the application
 
 ### Running it natively
+
 #### Installation
 
 ```bash
@@ -28,7 +29,9 @@ $ npm run start:prod
 ```
 
 ### Running it with Docker (local only)
+
 ```bash
+# Start the application (development)
 $ docker compose up
 ```
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ npm run start
 $ npm run start:prod
 ```
 
-### Running it with Docker
+### Running it with Docker (local only)
 ```bash
 $ docker compose up
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3"
+services:
+  astrobin-ng:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    healthcheck:
+      test: curl --fail http://127.0.0.1:4400/ || exit 1
+      interval: 10s
+      timeout: 3s
+      retries: 30
+    volumes:
+      - .:/code
+    expose:
+      - "4400"
+    ports:
+      - "4400:4400"
+    environment:
+      - NODE_PATH=/opt/deps/node_modules


### PR DESCRIPTION
This PR introduces the ability to run astrobin-ng locally within a Docker container. 
It includes a docker-compose.yml file and a Dockerfile to streamline the setup.